### PR TITLE
ginkgo-sepolicy:permissioncontroller: Access tethering_service

### DIFF
--- a/private/permissioncontroller_app.te
+++ b/private/permissioncontroller_app.te
@@ -1,0 +1,1 @@
+allow permissioncontroller_app tethering_service:service_manager find;


### PR DESCRIPTION
Sounds like upstream overlooked this.

Denial:
avc:  denied  { find } for name=tethering \
    scontext=u:r:permissioncontroller_app:s0:c141,c256,c512,c768 \
    tcontext=u:object_r:tethering_service:s0 \
    tclass=service_manager permissive=1